### PR TITLE
fix(ci): grant contents:write so gh-pages deploy can push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,12 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches:
-      - main  
+      - main
+
+# The repo's default GITHUB_TOKEN permission is read-only, so the deploy job
+# must explicitly request write access to push the built site to gh-pages.
+permissions:
+  contents: write
 
 jobs:
   build:
@@ -11,12 +16,12 @@ jobs:
 
     steps:
     - name: Checkout the repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: '22'  
+        node-version: '22'
 
     - name: Install dependencies
       run: yarn install
@@ -25,7 +30,7 @@ jobs:
       run: yarn build
 
     - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./dist   
+        publish_dir: ./dist

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: '22'
+        node-version: '24'
 
     - name: Install dependencies
       run: yarn install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - name: Checkout the repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: '22'
 
@@ -30,7 +30,7 @@ jobs:
       run: yarn build
 
     - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v4
+      uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./dist


### PR DESCRIPTION
## Problem

The [Deploy to GitHub Pages run](https://github.com/karida-org/meshtastic-configurator/actions/runs/27240969258) failed at the final step:

```
remote: Permission to karida-org/meshtastic-configurator.git denied to github-actions[bot].
fatal: ... The requested URL returned error: 403
```

The build itself succeeded. The failure was **not** caused by the vite bump that triggered the run.

## Root cause

The repository's default workflow token permission is `read` (Settings -> Actions -> Workflow permissions), and `.github/workflows/main.yml` declared no `permissions:` block. So `GITHUB_TOKEN` was read-only and `peaceiris/actions-gh-pages` could not push to the `gh-pages` branch.

## Fix

- Add `permissions: contents: write` so the deploy can push to `gh-pages`.
- Bump deprecated action majors (`checkout`/`setup-node` v3 -> v4, `actions-gh-pages` v3 -> v4).

No repo-settings change is required with this fix, since a workflow-level `permissions` block can request write above the read-only default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to explicitly grant write permission for publishing.
  * Pinned and upgraded CI actions and tooling for more stable, reproducible runs.
  * Bumped the Node.js runtime to version 24.
  * Upgraded the site-publishing action while keeping the same publish directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->