### PR TITLE
ci: Pages via Actions source + pinact + dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 8
+    groups:
+      github-actions:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 8
+    groups:
+      npm:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,33 +4,58 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
-# The repo's default GITHUB_TOKEN permission is read-only, so the deploy job
-# must explicitly request write access to push the built site to gh-pages.
+# Allow only one concurrent deployment, skipping runs queued between the
+# run in-progress and latest queued. Do not cancel in-progress runs as we
+# want to let production deployments complete.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+
+      - name: Configure Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build the project
+        run: yarn build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: ./dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+
+    # Grant the GITHUB_TOKEN the permissions required to deploy to Pages.
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-    - name: Checkout the repository
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-    - name: Setup Node.js
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-      with:
-        node-version: '24'
-
-    - name: Install dependencies
-      run: yarn install
-
-    - name: Build the project
-      run: yarn build
-
-    - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./dist
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -43,6 +45,8 @@ jobs:
           path: ./dist
 
   deploy:
+    # workflow_dispatch can be triggered from any branch; only ever publish main.
+    if: github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
 

--- a/.github/workflows/pinact-check.yml
+++ b/.github/workflows/pinact-check.yml
@@ -1,0 +1,12 @@
+name: Action Pinning Check
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  pinact:
+    uses: karida-org/.github/.github/workflows/reusable-pinact-check.yml@1c127977a1764bbe54fafa214b63cd19fbfccd67 # v1.2.0

--- a/.pinact.yml
+++ b/.pinact.yml
@@ -1,0 +1,44 @@
+# Canonical pinact config for the karida-org org.
+#
+# Drop this file at the root of your repository as `.pinact.yml`. pinact
+# reads it both locally (pre-commit, manual `pinact run`) and in CI (the
+# Action Pinning Check), so local and CI behave identically. Requires
+# pinact v4+ (the `version` field below).
+#
+# What it does:
+#
+#   min_age.value: 7    Do not pin (or update to) an action release that
+#                       is younger than 7 days. A freshly published tag or
+#                       release is the window when a hijacked-tag supply
+#                       chain attack is most likely to still be live, so
+#                       we wait it out. This is the GitHub Actions analog
+#                       of pnpm's `minimumReleaseAge`.
+#
+#   min_age.always: true  Verify the 7-day age of CURRENT pins on every
+#                       run, not only when `--verify-min-age` is passed.
+#                       Keeps the rule on by default for local runs.
+#
+#   rules (karida-org/*)  Exempt our own org from the cooldown. The 7-day
+#                       window guards against a hijacked THIRD-PARTY
+#                       release; we author and control karida-org/* releases
+#                       ourselves, and a brand-new karida-org/.github
+#                       reusable would otherwise be un-adoptable for a
+#                       week (no older release contains it). Still
+#                       SHA-pinned; Dependabot maintains them.
+#
+# Pin comments use pinact's default single-space separator (`@<sha> # vX.Y.Z`),
+# which is also what Prettier emits for YAML, so the two never fight.
+#
+# Bump an action by letting Dependabot (github-actions, weekly, with an
+# 8-day cooldown: one day over this min_age, so its PRs always clear the
+# pinact gate) open the PR, or run `pinact run --update` locally. Do not
+# hand-edit the SHA or the version comment; pinact keeps the two in sync.
+version: 3
+min_age:
+  value: 7
+  always: true
+rules:
+  - min_age: 0
+    conditions:
+      - expr: |
+          ActionName matches "karida-org/.*"


### PR DESCRIPTION
Follow-up to #9.

## Why
The deprecated-Node-20 warning came from GitHub's auto-generated `pages-build-deployment` workflow, which runs whenever the `gh-pages` branch changes (Pages source = legacy/branch). We can't edit that workflow's action versions. This PR removes that workflow from the picture entirely by switching to the **GitHub Actions** Pages source.

## Changes
- **`main.yml`**: replace `peaceiris/actions-gh-pages` (push to `gh-pages`) with the official flow: `configure-pages` -> build -> `upload-pages-artifact` -> `deploy-pages`. Split into `build` + `deploy` jobs with scoped `pages: write` / `id-token: write` permissions and a `pages` concurrency group. No more `gh-pages` branch.
- **`pinact-check.yml`**: adopt the org reusable Action Pinning Check (v1.2.0).
- **`.pinact.yml`**: canonical org config (7-day cooldown, `karida-org/*` exempt).
- **`dependabot.yml`**: github-actions + npm, weekly, 8-day cooldown.

All actions SHA-pinned to latest releases (checkout v6.0.3, setup-node v6.4.0, configure-pages v6.0.0, upload-pages-artifact v5.0.0, deploy-pages v5.0.0).

## Required settings change
Settings -> Pages -> **Source = GitHub Actions** (done via API alongside this PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency update checks for GitHub Actions and npm on a weekly cadence, grouping updates and limiting to minor/patch releases.
  * Modernized GitHub Pages deployment to an artifact-based two-step build/deploy flow with manual dispatch and improved concurrency/permissions.
  * Added repository-level action pinning controls with a 7-day minimum age and an exception rule for trusted organization actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->